### PR TITLE
Add authorization gate overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,19 +7,23 @@
   <script src="https://unpkg.com/@livechat/agent-app-sdk@1.6.3/dist/agentapp.umd.min.js"></script>
   <script src="https://alcdn.msauth.net/browser/2.38.1/js/msal-browser.min.js"></script>
   <style>
-    body { 
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif; 
-      margin: 0; 
-      background: #fff; 
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+      margin: 0;
+      background: #fff;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
       text-rendering: optimizeLegibility;
     }
+    body.authorized .app-content { display: block; }
+    body.authorized .auth-overlay { display: none; }
+    body.unauthorized .app-content { display: none; }
+    .app-content { display: none; }
     .card { max-width: 760px; margin: 20px auto; padding: 20px; background: #fff; border: 1px solid #e1e5e9; border-radius: 12px; }
     h3 { margin: 0 0 16px 0; font-size: 16px; font-weight: 500; color: #1d2129; }
     .controls { display: flex; gap: 8px; margin-bottom: 16px; }
-    button { 
-      padding: 8px 12px; 
+    button {
+      padding: 8px 12px;
       border: 1px solid #ccd0d5; 
       border-radius: 6px;
       background: #f5f6f7; 
@@ -325,10 +329,35 @@
     .ms-auth-note {
       color: #65676b;
     }
+
+    .auth-overlay {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      text-align: center;
+      min-height: 200px;
+      padding: 40px 20px;
+    }
+
+    .auth-overlay p {
+      margin: 0;
+      color: #65676b;
+      font-size: 14px;
+      line-height: 1.4;
+    }
   </style>
 </head>
 <body>
   <div class="card">
+    <div id="authOverlay" class="auth-overlay">
+      <h3>Multilogin AI Helper</h3>
+      <p>Sign in with Microsoft 365 to unlock the widget features.</p>
+      <button id="overlayAuthBtn">Sign in with Microsoft 365</button>
+    </div>
+
+    <div class="app-content">
     <div class="widget-header">
       <h3>Multilogin AI Helper</h3>
       <div class="menu-container">
@@ -419,10 +448,12 @@
       </div>
     </div>
 
+    </div> <!-- /.app-content -->
   </div>
 
   <script>
     (async () => {
+      document.body.classList.add('unauthorized');
       const statusEl = document.getElementById('status');
       const loadingEl = document.getElementById('loadingIndicator');
       const btnAdd = document.getElementById('addTagBtn');
@@ -438,6 +469,7 @@
       const msAuthAccount = document.getElementById('msAuthAccount');
       const msAuthNote = document.querySelector('.ms-auth-note');
       const menuBtn = document.querySelector('.menu-btn');
+      const overlayAuthBtn = document.getElementById('overlayAuthBtn');
 
       const MSAL_CONFIG = {
         auth: {
@@ -532,6 +564,9 @@
       function updateMsAuthUI() {
         const authorized = Boolean(msAccount);
 
+        document.body.classList.toggle('authorized', authorized);
+        document.body.classList.toggle('unauthorized', !authorized);
+
         if (btnAdd) {
           btnAdd.disabled = !authorized;
           btnAdd.title = authorized
@@ -578,9 +613,16 @@
           msSignOutBtn.disabled = !authorized;
         }
 
+        const authButtonLabel = authorized ? 'Switch Microsoft 365 account' : 'Sign in with Microsoft 365';
+
         if (msAuthBtn) {
-          msAuthBtn.textContent = authorized ? 'Switch Microsoft 365 account' : 'Sign in with Microsoft 365';
+          msAuthBtn.textContent = authButtonLabel;
           msAuthBtn.disabled = !msalInstance;
+        }
+
+        if (overlayAuthBtn) {
+          overlayAuthBtn.textContent = authButtonLabel;
+          overlayAuthBtn.disabled = !msalInstance;
         }
 
         if (msAuthNote) {
@@ -709,6 +751,10 @@
             msAuthBtn.disabled = true;
             msAuthBtn.textContent = 'MSAL not loaded';
           }
+          if (overlayAuthBtn) {
+            overlayAuthBtn.disabled = true;
+            overlayAuthBtn.textContent = 'MSAL not loaded';
+          }
           return;
         }
 
@@ -781,6 +827,10 @@
 
       if (msSignOutBtn) {
         msSignOutBtn.addEventListener('click', handleMsalLogout);
+      }
+
+      if (overlayAuthBtn) {
+        overlayAuthBtn.addEventListener('click', handleMsalLogin);
       }
 
       updateMsAuthUI();


### PR DESCRIPTION
## Summary
- add an authorization overlay that limits unauthenticated users to the Microsoft 365 sign-in action
- toggle the main widget interface based on the current Microsoft 365 session state while preserving existing logic

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3cc18da748330a3d2473c0156d6af